### PR TITLE
Added resolver instruction to fix Amazon ELB DNS

### DIFF
--- a/servers/scripts/run.sh
+++ b/servers/scripts/run.sh
@@ -1,8 +1,6 @@
 #!/bin/sh
 
-grep 'upstream target' /usr/local/nginx/sites-enabled/base.conf || \
-	(echo "upstream target { server $TARGET:80; }" && cat /usr/local/nginx/sites-enabled/base.conf) > base.conf.new
-
-mv base.conf.new /usr/local/nginx/sites-enabled/base.conf
+grep 'TARGET:80' /usr/local/nginx/sites-enabled/base.conf && \
+    sed -i "s/TARGET:80/$TARGET:80/g" /usr/local/nginx/sites-enabled/base.conf
 
 /usr/local/nginx/sbin/nginx -g 'daemon off;'

--- a/servers/sites-enabled/base.conf
+++ b/servers/sites-enabled/base.conf
@@ -2,13 +2,19 @@ server {
 
   listen 80;
   server_name ~^[0-9]*;
+
+  resolver 8.8.8.8 valid=10s;
+  resolver_timeout 10s;
+
+  set $backend_upstream "TARGET:80";
+
   proxy_set_header Host $host;
   proxy_set_header X-Real-IP $remote_addr;
   proxy_set_header X-Forwarded-For $remote_addr;
   proxy_set_header X-Forwarded-Proto $scheme;
 
   location / {
-    proxy_pass       http://target;
+    proxy_pass       http://$backend_upstream;
     proxy_set_header Host $host;
   }
 }


### PR DESCRIPTION
Unfortunately, we still have an issue when Amazon changing DNS records for internal ELB and because of that, NGINX throws 504 bad gateway error.

https://gist.github.com/cpswan/966b9c6c88230e0c4ffc
https://tenzer.dk/nginx-with-dynamic-upstreams/
https://www.jethrocarr.com/2013/11/02/nginx-reverse-proxies-and-dns-resolution/
http://ghost.thekindof.me/nginx-aws-elb-dns-resolution-nginx-resolver-directive-and-black-magic/
